### PR TITLE
Ensure Blosc2 is initialized for read-only entrypoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ target
 #.idea/
 
 /.vscode
+.cargo-home/
+.rustup-home/

--- a/blosc2/src/chunk/chunk.rs
+++ b/blosc2/src/chunk/chunk.rs
@@ -62,6 +62,8 @@ impl<'a> Chunk<'a> {
     ///
     /// This function is very cheap.
     pub fn from_compressed(bytes: CowVec<'a, u8>) -> Result<Self, Error> {
+        crate::global::global_init();
+
         let (nbytes, _cbytes, _blocksize) =
             validate_compressed_buf_and_get_sizes(bytes.as_slice())?;
 

--- a/blosc2/src/chunk/encode.rs
+++ b/blosc2/src/chunk/encode.rs
@@ -18,6 +18,8 @@ pub struct Encoder(Context);
 impl Encoder {
     /// Create a new `Encoder` with the given compression parameters.
     pub fn new(params: CParams) -> Result<Self, Error> {
+        crate::global::global_init();
+
         let ctx = unsafe { blosc2_sys::blosc2_create_cctx(params.0) };
         let ctx = NonNull::new(ctx).ok_or(Error::Failure)?;
         Ok(Self(Context(ctx)))
@@ -235,6 +237,8 @@ pub struct Decoder(Context);
 impl Decoder {
     /// Create a new `Decoder` with the given decompression parameters.
     pub fn new(params: DParams) -> Result<Self, Error> {
+        crate::global::global_init();
+
         let ctx = unsafe { blosc2_sys::blosc2_create_dctx(params.0) };
         let ctx = NonNull::new(ctx).ok_or(Error::Failure)?;
         Ok(Self(Context(ctx)))

--- a/blosc2/src/chunk/schunk.rs
+++ b/blosc2/src/chunk/schunk.rs
@@ -92,7 +92,7 @@ impl SChunk {
     ) -> Result<Self, Error> {
         crate::global::global_init();
 
-        let urlpath = storage.urlpath.map(path2cstr);
+        let urlpath = storage.urlpath.map(path2cstr).transpose()?;
         let urlpath = urlpath
             .as_ref()
             .map(|p| p.as_ptr().cast_mut())
@@ -118,7 +118,7 @@ impl SChunk {
     pub fn open_with_options(urlpath: &Path, options: &SChunkOpenOptions) -> Result<Self, Error> {
         crate::global::global_init();
 
-        let urlpath = path2cstr(urlpath);
+        let urlpath = path2cstr(urlpath)?;
         let schunk = match &options.mmap {
             None => unsafe {
                 blosc2_sys::blosc2_schunk_open_offset(urlpath.as_ptr(), options.offset as _)
@@ -187,7 +187,7 @@ impl SChunk {
     /// * `append` - If true, the super chunk will be appended to the file. If false, the file
     ///   should not exist, otherwise an error will be returned.
     pub fn to_file(&mut self, urlpath: &Path, append: bool) -> Result<(), Error> {
-        let urlpath = path2cstr(urlpath);
+        let urlpath = path2cstr(urlpath)?;
         unsafe {
             if append {
                 blosc2_sys::blosc2_schunk_append_file(self.0.as_ptr(), urlpath.as_ptr().cast_mut())
@@ -391,7 +391,7 @@ impl SChunk {
     ) -> Result<SChunk, Error> {
         crate::global::global_init();
 
-        let urlpath = storage.urlpath.map(path2cstr);
+        let urlpath = storage.urlpath.map(path2cstr).transpose()?;
         let urlpath = urlpath
             .as_ref()
             .map(|p| p.as_ptr().cast_mut())

--- a/blosc2/src/chunk/schunk.rs
+++ b/blosc2/src/chunk/schunk.rs
@@ -145,6 +145,8 @@ impl SChunk {
 
     /// Create a super chunk from an existing in-memory buffer.
     pub fn from_buffer(buffer: CowVec<u8>) -> Result<Self, Error> {
+        crate::global::global_init();
+
         let buffer = BytesMaybePassOwnershipToC::new(buffer);
         let schunk = unsafe {
             blosc2_sys::blosc2_schunk_from_buffer(

--- a/blosc2/src/error.rs
+++ b/blosc2/src/error.rs
@@ -169,8 +169,12 @@ impl Error {
 }
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        crate::global::global_init();
+
         let err_str = unsafe { blosc2_sys::blosc2_error_string(self.to_int()) };
-        assert!(!err_str.is_null());
+        if err_str.is_null() {
+            return f.write_str("blosc2: unknown error");
+        }
         let len = unsafe { libc::strlen(err_str) };
         let err_str: &'static [u8] = unsafe { std::slice::from_raw_parts(err_str.cast(), len + 1) };
         let err_str = std::ffi::CStr::from_bytes_with_nul(err_str).unwrap();

--- a/blosc2/src/misc.rs
+++ b/blosc2/src/misc.rs
@@ -7,6 +7,8 @@ use crate::CompressAlgo;
 
 /// Get a list of compressors names supported in the current build.
 pub fn list_compressors() -> impl Iterator<Item = &'static str> {
+    crate::global::global_init();
+
     let compressors = unsafe { blosc2_sys::blosc2_list_compressors() };
     let len = unsafe { libc::strlen(compressors) };
     let slice: &'static [u8] = unsafe { std::slice::from_raw_parts(compressors.cast(), len + 1) };
@@ -25,6 +27,8 @@ pub fn list_compressors() -> impl Iterator<Item = &'static str> {
 ///
 /// A tuple containing the compression library name and its version.
 pub fn compressor_lib_info(compressor: CompressAlgo) -> (String, String) {
+    crate::global::global_init();
+
     let mut compname = MaybeUninit::uninit();
     unsafe { blosc2_sys::blosc2_compcode_to_compname(compressor as _, compname.as_mut_ptr()) };
     let compname = unsafe { compname.assume_init() };

--- a/blosc2/src/nd/mod.rs
+++ b/blosc2/src/nd/mod.rs
@@ -118,7 +118,7 @@ impl Ndarray {
 
         crate::global::global_init();
 
-        let urlpath = storage.urlpath.map(path2cstr);
+        let urlpath = storage.urlpath.map(path2cstr).transpose()?;
         let urlpath = urlpath
             .as_ref()
             .map(|p| p.as_ptr().cast_mut())
@@ -1498,7 +1498,9 @@ impl Ndarray {
     ///
     /// The offset of the saved array in the file.
     pub fn save(&self, urlpath: &Path, append: bool) -> Result<u64, Error> {
-        let urlpath = path2cstr(urlpath);
+        crate::global::global_init();
+
+        let urlpath = path2cstr(urlpath)?;
         let offset = if !append {
             unsafe { blosc2_sys::b2nd_save(self.as_ptr(), urlpath.as_ptr().cast_mut()) }
                 .into_result()?;

--- a/blosc2/src/nd/params.rs
+++ b/blosc2/src/nd/params.rs
@@ -101,6 +101,8 @@ impl Ctx {
         dtype: &CStr,
         dtype_format: i8,
     ) -> Result<Self, Error> {
+        crate::global::global_init();
+
         let ndim = shape.len();
         if chunkshape.len() != ndim || blockshape.len() != ndim {
             crate::trace!(

--- a/blosc2/src/params.rs
+++ b/blosc2/src/params.rs
@@ -81,6 +81,7 @@ pub enum SplitMode {
 pub struct CParams(pub(crate) blosc2_sys::blosc2_cparams);
 impl Default for CParams {
     fn default() -> Self {
+        crate::global::global_init();
         Self(unsafe { blosc2_sys::blosc2_get_blosc2_cparams_defaults() })
     }
 }
@@ -268,6 +269,7 @@ impl std::fmt::Debug for CParams {
 pub struct DParams(pub(crate) blosc2_sys::blosc2_dparams);
 impl Default for DParams {
     fn default() -> Self {
+        crate::global::global_init();
         Self(unsafe { blosc2_sys::blosc2_get_blosc2_dparams_defaults() })
     }
 }

--- a/blosc2/tests/chunk_from_compressed_init.rs
+++ b/blosc2/tests/chunk_from_compressed_init.rs
@@ -1,0 +1,26 @@
+use blosc2::chunk::Chunk;
+use blosc2::util::CowVec;
+
+const CHUNK_HEX: &str = "05010701080000000800000028000000000000000001000000000000000000000102030405060708";
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    assert!(hex.len() % 2 == 0);
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    let bytes = hex.as_bytes();
+    for i in (0..bytes.len()).step_by(2) {
+        let hi = (bytes[i] as char).to_digit(16).unwrap();
+        let lo = (bytes[i + 1] as char).to_digit(16).unwrap();
+        out.push(((hi << 4) | lo) as u8);
+    }
+    out
+}
+
+#[test]
+fn chunk_from_compressed_initializes_global_state() {
+    // Regression test: `Chunk::from_compressed` must work even if Blosc2 was never initialized
+    // in this process yet.
+    let compressed = decode_hex(CHUNK_HEX);
+    let chunk = Chunk::from_compressed(CowVec::from(compressed)).unwrap();
+    assert_eq!(chunk.decompress().unwrap(), vec![1, 2, 3, 4, 5, 6, 7, 8]);
+}
+

--- a/blosc2/tests/compressor_lib_info_init.rs
+++ b/blosc2/tests/compressor_lib_info_init.rs
@@ -1,0 +1,11 @@
+use blosc2::CompressAlgo;
+
+#[test]
+fn compressor_lib_info_initializes_global_state() {
+    // Regression test: calling into the misc API should work even if Blosc2 was never initialized
+    // in this process yet.
+    let (lib, version) = blosc2::compressor_lib_info(CompressAlgo::Blosclz);
+    assert!(!lib.is_empty());
+    assert!(!version.is_empty());
+}
+

--- a/blosc2/tests/error_display_init.rs
+++ b/blosc2/tests/error_display_init.rs
@@ -1,0 +1,8 @@
+#[test]
+fn error_display_initializes_global_state() {
+    // Regression test: formatting an Error should be safe as the first interaction with the crate
+    // (e.g. when an error is constructed without calling into Blosc2 first).
+    let s = format!("{}", blosc2::Error::InvalidParam);
+    assert!(!s.is_empty());
+}
+

--- a/blosc2/tests/from_buffer_init.rs
+++ b/blosc2/tests/from_buffer_init.rs
@@ -1,0 +1,42 @@
+use blosc2::chunk::SChunk;
+use blosc2::util::CowVec;
+
+const SCHUNK_BUF_HEX: &str = concat!(
+    "9ea862326672616d6500d200000061cf00000000000000d4a412005003d30000000000000008",
+    "d30000000000000028d200000008d200000008d200000008d10000d10001c2d8060000000000",
+    "010000000000000000000093cd0007de0000dc00000501070808000000080000002800000000",
+    "0000000001000000000000000000000102030405060708050107080800000008000000280000",
+    "00000000000001000000000000000000000000000000000000940193cd0006de0000dc0000",
+    "ce00000023d80000000000000000000000000000000000",
+);
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    assert!(
+        hex.len() % 2 == 0,
+        "hex string must have even length, got {}",
+        hex.len()
+    );
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    let bytes = hex.as_bytes();
+    for i in (0..bytes.len()).step_by(2) {
+        let hi = (bytes[i] as char)
+            .to_digit(16)
+            .unwrap_or_else(|| panic!("invalid hex char {:?}", bytes[i] as char));
+        let lo = (bytes[i + 1] as char)
+            .to_digit(16)
+            .unwrap_or_else(|| panic!("invalid hex char {:?}", bytes[i + 1] as char));
+        out.push(((hi << 4) | lo) as u8);
+    }
+    out
+}
+
+#[test]
+fn from_buffer_initializes_global_state() {
+    // Regression test: `SChunk::from_buffer` must work even if Blosc2 was never initialized in
+    // this process yet (i.e. no prior `SChunk::new`/`open` calls).
+    let buffer = decode_hex(SCHUNK_BUF_HEX);
+
+    let mut schunk = SChunk::from_buffer(CowVec::from(buffer)).unwrap();
+    assert_eq!(schunk.num_chunks(), 1);
+    assert_eq!(schunk.get_chunk(0).unwrap().decompress().unwrap(), vec![1, 2, 3, 4, 5, 6, 7, 8]);
+}

--- a/blosc2/tests/list_compressors_init.rs
+++ b/blosc2/tests/list_compressors_init.rs
@@ -1,0 +1,8 @@
+#[test]
+fn list_compressors_initializes_global_state() {
+    // Regression test: calling into the misc API should work even if Blosc2 was never initialized
+    // in this process yet.
+    let compressors: Vec<&'static str> = blosc2::list_compressors().collect();
+    assert!(!compressors.is_empty());
+}
+

--- a/blosc2/tests/non_utf8_paths.rs
+++ b/blosc2/tests/non_utf8_paths.rs
@@ -1,0 +1,16 @@
+#[test]
+fn nul_in_paths_returns_error_instead_of_panicking() {
+    use std::path::PathBuf;
+
+    use blosc2::chunk::SChunk;
+    use blosc2::{CParams, DParams, Error};
+
+    // Paths with interior NUL cannot be represented as C strings; ensure we don't panic.
+    let urlpath = PathBuf::from("bad\0path");
+
+    let err = match SChunk::new_on_disk(&urlpath, CParams::default(), DParams::default()) {
+        Ok(_) => panic!("expected invalid path error"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, Error::InvalidParam));
+}

--- a/blosc2/tests/params_default_init.rs
+++ b/blosc2/tests/params_default_init.rs
@@ -1,0 +1,12 @@
+use blosc2::{CParams, DParams};
+
+#[test]
+fn params_default_initializes_global_state() {
+    // Regression test: `CParams::default` / `DParams::default` should be safe as the first API
+    // calls in a process.
+    let cparams = CParams::default();
+    let dparams = DParams::default();
+    assert!(cparams.get_typesize() > 0);
+    assert!(dparams.get_nthreads() >= 1);
+}
+


### PR DESCRIPTION
  - Fixes a crash/“Generic failure” on read-only paths where blosc2::chunk::SChunk::from_buffer(...) (and other read-side APIs) could be called before blosc2_init(), leaving C-blosc2 global
    state uninitialized.
  - Makes internal path-to-C-string conversion non-panicking and returns Error::InvalidParam for paths that can’t be represented as CString (e.g. interior NUL).
  - Hardens a couple of misc FFI helpers against null pointers to avoid panics in degenerate cases.
  - Adds regression tests to ensure read-only APIs work as the first Blosc2 API used in a process.
